### PR TITLE
added multiple thermostat support, and 'name' method

### DIFF
--- a/lib/nest_thermostat/version.rb
+++ b/lib/nest_thermostat/version.rb
@@ -1,3 +1,3 @@
 module NestThermostat
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
I added support for multiple thermostats using an optional thermostat_idx: parameter to initialize, and a "name" method to pull that thermostat's name.  

Great work BTW -- cheers.
