### PR TITLE
Optimized the temp_scale matching regexes

### DIFF
--- a/lib/nest_thermostat/nest.rb
+++ b/lib/nest_thermostat/nest.rb
@@ -132,9 +132,9 @@ module NestThermostat
 
     def convert_temp_for_get(degrees)
       case self.temperature_scale
-      when /f|F|(F|f)ahrenheit/
+      when /[fF](ahrenheit)?/
         c2f(degrees).round(3)
-      when /k|K|(K|k)elvin/
+      when /[kK](elvin)?/
         c2k(degrees).round(3)
       else
         degrees
@@ -143,9 +143,9 @@ module NestThermostat
 
     def convert_temp_for_set(degrees)
       case self.temperature_scale
-      when /f|F|(F|f)ahrenheit/
+      when /[fF](ahrenheit)?/
         f2c(degrees).round(5)
-      when /k|K|(K|k)elvin/
+      when /[kK](elvin)?/
         k2c(degrees).round(5)
       else
         degrees


### PR DESCRIPTION
Small optimization with the regexes used to math the temperature scale. Removed the redundant matching of the alternators.
