### PR TITLE
Rename `away` and `leaf` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ puts @nest.temperature           # => 73.00
 puts @nest.temp                  # => 73.00
 puts @nest.target_temperature_at # => 2012-06-05 14:28:48 +0000 # Ruby date object or false
 puts @nest.target_temp_at        # => 2012-06-05 14:28:48 +0000 # Ruby date object or false
-puts @nest.away                  # => false
-puts @nest.leaf                  # => true # May take a few seconds after a temp change
+puts @nest.away?                 # => false
+puts @nest.leaf?                 # => true # May take a few seconds after a temp change
 puts @nest.humidity              # => 54 # Relative humidity in percent
 ```
 
@@ -39,9 +39,9 @@ puts @nest.temperature # => 73.0
 puts @nest.temperature = 74.0
 puts @nest.temperature # => 74.0
 
-puts @nest.away # => false
+puts @nest.away? # => false
 puts @nest.away = true
-puts @nest.away # => true
+puts @nest.away? # => true
 ```
 
 By default, temperatures are in fahrenheit, but you can change this to `:celsius` or `:kelvin`.

--- a/lib/nest_thermostat/nest.rb
+++ b/lib/nest_thermostat/nest.rb
@@ -55,7 +55,7 @@ module NestThermostat
       status["track"][self.device_id]["last_ip"].strip
     end
 
-    def leaf
+    def leaf?
       status["device"][self.device_id]["leaf"]
     end
 
@@ -90,7 +90,7 @@ module NestThermostat
     end
     alias_method :target_temp_at, :target_temperature_at
 
-    def away
+    def away?
       status["structure"][structure_id]["away"]
     end
 
@@ -121,6 +121,16 @@ module NestThermostat
         body: %Q({"fan_mode":"#{state}"}),
         headers: self.headers
       ) rescue nil
+    end
+
+    def method_missing(name, *args, &block)
+      if %i[away leaf].include?(name)
+        warn "`#{name}' has been replaced with `#{name}?'. Support for " +
+             "`#{name}' without the '?' will be dropped in future versions."
+        return self.send("#{name}?", *args)
+      end
+
+      super
     end
 
     private

--- a/spec/nest_thermostat_spec.rb
+++ b/spec/nest_thermostat_spec.rb
@@ -32,18 +32,18 @@ module NestThermostat
     end
 
     it "gets the leaf status" do
-      expect(@nest.leaf).to_not be_nil
+      expect(@nest.leaf?).to_not be_nil
     end
 
     it "gets away status" do
-      expect(@nest.away).to_not be_nil
+      expect(@nest.away?).to_not be_nil
     end
 
     it "sets away status" do
       @nest.away = true
-      expect(@nest.away).to be(true)
+      expect(@nest.away?).to be(true)
       @nest.away = false
-      expect(@nest.away).to be(false)
+      expect(@nest.away?).to be(false)
     end
 
     it "gets the current temperature" do


### PR DESCRIPTION
Closes #14. It provides a deprecation warning when `away` or `leaf` is called, telling the user how to use the new method (but it still works).
