### PR TITLE
High and low temps

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ puts nest.current_temperature   # => 75.00
 puts nest.current_temp          # => 75.00
 puts nest.temperature           # => 73.00
 puts nest.temp                  # => 73.00
+puts nest.temp_high             # => 77.00
+puts nest.temp_low              # => 71.00
+puts nest.temperature_high      # => 77.00
+puts nest.temperature_low       # => 71.00
 puts nest.target_temperature_at # => 2012-06-05 14:28:48 +0000 # Ruby date object or false
 puts nest.target_temp_at        # => 2012-06-05 14:28:48 +0000 # Ruby date object or false
 puts nest.away                  # => false
@@ -41,6 +45,14 @@ Change the temperature or away status:
 puts nest.temperature # => 73.0
 puts nest.temperature = 74.0
 puts nest.temperature # => 74.0
+
+puts nest.temperature_high # => 75.0
+puts nest.temperature_high = 74.0
+puts nest.temperature_high # => 74.0
+
+puts nest.temperature_low # => 65.0
+puts nest.temperature_low = 67.0
+puts nest.temperature_low # => 67.0
 
 puts nest.away? # => false
 puts nest.away = true

--- a/lib/nest_thermostat/nest.rb
+++ b/lib/nest_thermostat/nest.rb
@@ -73,6 +73,16 @@ module NestThermostat
     end
     alias_method :temp, :temperature
 
+    def temperature_low
+      convert_temp_for_get(status["shared"][self.device_id]["target_temperature_low"])
+    end
+    alias_method :temp_low, :temperature_low
+
+    def temperature_high
+      convert_temp_for_get(status["shared"][self.device_id]["target_temperature_high"])
+    end
+    alias_method :temp_high, :temperature_high
+
     def temperature=(degrees)
       degrees = convert_temp_for_set(degrees)
 
@@ -83,6 +93,28 @@ module NestThermostat
       ) rescue nil
     end
     alias_method :temp=, :temperature=
+
+    def temperature_low=(degrees)
+      degrees = convert_temp_for_set(degrees)
+
+      request = HTTParty.post(
+          "#{self.transport_url}/v2/put/shared.#{self.device_id}",
+          body: %Q({"target_change_pending":true,"target_temperature_low":#{degrees}}),
+          headers: self.headers
+      ) rescue nil
+    end
+    alias_method :temp_low=, :temperature_low=
+
+    def temperature_high=(degrees)
+      degrees = convert_temp_for_set(degrees)
+
+      request = HTTParty.post(
+          "#{self.transport_url}/v2/put/shared.#{self.device_id}",
+          body: %Q({"target_change_pending":true,"target_temperature_high":#{degrees}}),
+          headers: self.headers
+      ) rescue nil
+    end
+    alias_method :temp_high=, :temperature_high=
 
     def target_temperature_at
       epoch = status["device"][self.device_id]["time_to_target"]

--- a/lib/nest_thermostat/version.rb
+++ b/lib/nest_thermostat/version.rb
@@ -1,3 +1,3 @@
 module NestThermostat
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/spec/nest_thermostat_spec.rb
+++ b/spec/nest_thermostat_spec.rb
@@ -60,12 +60,38 @@ module NestThermostat
       expect(@nest.temp).to be_a_kind_of(Numeric)
     end
 
+    it "gets the low temperature" do
+      expect(@nest.temperature_low).to be_a_kind_of(Numeric)
+      expect(@nest.temp_low).to be_a_kind_of(Numeric)
+    end
+
+    it "gets the high temperature" do
+      expect(@nest.temperature_high).to be_a_kind_of(Numeric)
+      expect(@nest.temp_high).to be_a_kind_of(Numeric)
+    end
+
     it "sets the temperature" do
       @nest.temp = '74'
       expect(@nest.temp.round).to eq(74)
 
       @nest.temperature = '73'
       expect(@nest.temperature).to eq(73)
+    end
+
+    it "sets the low temperature" do
+      @nest.temp_low = '73'
+      expect(@nest.temp_low.round).to eq(73)
+
+      @nest.temperature_low = '74'
+      expect(@nest.temperature_low.round).to eq(74)
+    end
+
+    it "sets the high temperature" do
+      @nest.temp_high = '73'
+      expect(@nest.temp_high.round).to eq(73)
+
+      @nest.temperature_high = '74'
+      expect(@nest.temperature_high.round).to eq(74)
     end
 
     it "sets the temperature in celsius" do


### PR DESCRIPTION
Nest's high and low temperature feature is great if you live in a climate that changes frequently and don't want to set your AC to cool only to need heat a little bit later.

This PR adds support for setting and reading these properties as this was a feature that I needed.

```ruby
2.1.4 :001 > load './lib/nest_thermostat.rb'
 => true
2.1.4 :002 > nest = NestThermostat::Nest.new(email: ENV['NEST_EMAIL'], password: ENV['NEST_PASS'])
 => #<NestThermo...
2.1.4 :003 > nest.temp_high
 => 73.99999
2.1.4 :004> nest.temp_high = 75
 => 75
2.1.4 :005 > nest.temp_high
 => 74.99999
2.1.4 :006 > nest.temp_low
 => 70.99999
2.1.4 :007 > nest.temp_low = 72
 => 72
2.1.4 :008 > nest.temp_low
 => 71.99999
```
I tried to update the README and tests to be consistent with what was already in place.